### PR TITLE
add permission keyword arg to append or create

### DIFF
--- a/lib/webhdfs/client_v1.rb
+++ b/lib/webhdfs/client_v1.rb
@@ -296,11 +296,12 @@ module WebHDFS
     alias :settimes :touch
 
     # Higher level
-    def append_or_create(path, data)
+    def append_or_create(path, data, permission: nil)
       stat(path)
       append(path, data + "\n")
     rescue WebHDFS::FileNotFoundError
-      create(path, data + "\n")
+      options = permissions.nil? ? {} : { 'permission' => permission }
+      create(path, data + "\n", options)
     end
 
     def delete_recursive(path)

--- a/lib/webhdfs/client_v1.rb
+++ b/lib/webhdfs/client_v1.rb
@@ -300,7 +300,7 @@ module WebHDFS
       stat(path)
       append(path, data + "\n")
     rescue WebHDFS::FileNotFoundError
-      options = permissions.nil? ? {} : { 'permission' => permission }
+      options = permission.nil? ? {} : { 'permission' => permission }
       create(path, data + "\n", options)
     end
 


### PR DESCRIPTION
append doesn't allow a permission parameter so we only add it in the case
of create. therefore we can't just pass an options hash into the
append_or_create method itself; we'll have to make it more fine grained than that

----
#### testing
manually tested that the files are created with the appropriate permissions when provided